### PR TITLE
Update food-and-agriculture-organization-of-the-united-nations.csl

### DIFF
--- a/food-and-agriculture-organization-of-the-united-nations.csl
+++ b/food-and-agriculture-organization-of-the-united-nations.csl
@@ -14,13 +14,13 @@
     </author>
     <contributor>
       <name>Julian Plummer</name>
-      <email>Julian.Plummer@fao.org</email>
+      <email>julian.plummer@gmail.com</email>
     </contributor>
     <category citation-format="author-date"/>
     <category field="science"/>
     <category field="social_science"/>
     <summary>This style is created to meet the citation and bibliographical requirements of FAOSTYLE, and has been tested with Zotero and Mendeley. Last update: March 2017.</summary>
-    <updated>2017-03-10T01:12:03+01:00</updated>
+    <updated>2021-06-07T23:29:39+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <!-- Locale settings for English. Settings for other languages could be added later to this section. -->
@@ -61,7 +61,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="."/>
+      <name form="short" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with="."/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
@@ -116,6 +116,20 @@
       <text variable="URL"/>
     </group>
   </macro>
+  <macro name="DOI-or-available-at">
+    <!-- If DOI exists, then DOI is shown as: https://doi.org/DOI. If DOI doesn't exist, then "also available at URL" is shown. -->
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else>
+        <group delimiter=" " prefix="(" suffix=").">
+          <text term="available at"/>
+          <text variable="URL"/>
+        </group>
+      </else>
+    </choose>   
+  </macro>
   <macro name="number_of_pages-label">
     <!-- 1 p. / x pp. -->
     <group delimiter=" ">
@@ -124,7 +138,7 @@
     </group>
   </macro>
   <!-- in-line citation: (author, date) -->
-  <citation disambiguate-add-year-suffix="true" collapse="year" et-al-min="4" et-al-use-first="1">
+  <citation disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key variable="author"/>
       <key variable="issued"/>
@@ -168,7 +182,7 @@
                 </group>
                 <text macro="publisher-and-place" suffix="."/>
                 <text macro="number_of_pages-label"/>
-                <text macro="Available-at"/>
+                <text macro="DOI-or-available-at"/>
               </if>
               <else-if type="chapter report" match="any">
                 <!-- book section and report -->
@@ -196,7 +210,7 @@
                   <text macro="publisher-and-place"/>
                   <text macro="number_of_pages-label"/>
                 </group>
-                <text macro="Available-at"/>
+                <text macro="DOI-or-available-at"/>
               </else-if>
               <else-if type="article-journal">
                 <!-- paper journal article -->
@@ -207,15 +221,7 @@
                   <text variable="issue" prefix="(" suffix=")"/>
                   <text variable="page" prefix=": "/>
                 </group>
-                <choose>
-                  <!-- If DOI exists, then DOI is shown as: https://doi.org/DOI . If DOI doesn't exist, then "also available at URL" is shown. -->
-                  <if variable="DOI">
-                    <text variable="DOI" prefix="https://doi.org/"/>
-                  </if>
-                  <else>
-                    <text macro="Available-at"/>
-                  </else>
-                </choose>
+                <text macro="DOI-or-available-at"/>
               </else-if>
               <else-if type="article-magazine">
                 <!-- magazine and online-only journal article -->
@@ -270,7 +276,7 @@
                 <text variable="title" font-style="italic"/>
                 <text macro="publisher-and-place"/>
                 <text variable="genre" prefix=" (" suffix=")"/>
-                <text macro="Available-at"/>
+                <text macro="DOI-or-available-at"/>
               </else-if>
               <else-if type="song motion_picture article" match="any">
                 <!-- audio recording, film, and video recording in Zotero; film and computer program in Mendeley -->
@@ -329,7 +335,7 @@
                   <date form="text" variable="issued" prefix=", "/>
                   <text variable="publisher-place" prefix=", "/>
                 </group>
-                <text macro="Available-at"/>
+                <text macro="DOI-or-available-at"/>
               </else-if>
               <else>
                 <!-- other item types -->


### PR DESCRIPTION
Adjust the code so that most item types show DOI if DOI exists, and show "also available at URL" if DOI doesn't exist. This is according to the suggestion at: https://github.com/zotero/translators/pull/2249#discussion_r646665445.

Also move et-al usage to "author-short" macro.